### PR TITLE
feat: Add Qwen LLM support and configurable max retries

### DIFF
--- a/midscene-core/src/main/java/com/midscene/core/agent/Agent.java
+++ b/midscene-core/src/main/java/com/midscene/core/agent/Agent.java
@@ -10,6 +10,7 @@ import com.midscene.core.model.GeminiModel;
 import com.midscene.core.model.MistralModel;
 import com.midscene.core.model.OllamaModel;
 import com.midscene.core.model.OpenAIModel;
+import com.midscene.core.model.QwenModel;
 import com.midscene.core.pojo.options.InputOptions;
 import com.midscene.core.pojo.options.LocateOptions;
 import com.midscene.core.pojo.options.ScrollOptions;
@@ -30,15 +31,17 @@ public class Agent {
   private TaskCache cache;
 
   public Agent(PageDriver driver, AIModel aiModel) {
-    this.driver = driver;
-    this.cache = TaskCache.disabled();
-    this.orchestrator = new Orchestrator(driver, aiModel, this.cache);
+    this(driver, aiModel, TaskCache.disabled(), 3);
   }
 
   public Agent(PageDriver driver, AIModel aiModel, TaskCache cache) {
+    this(driver, aiModel, cache, 3);
+  }
+
+  public Agent(PageDriver driver, AIModel aiModel, TaskCache cache, int maxRetries) {
     this.driver = driver;
     this.cache = cache != null ? cache : TaskCache.disabled();
-    this.orchestrator = new Orchestrator(driver, aiModel, this.cache);
+    this.orchestrator = new Orchestrator(driver, aiModel, this.cache, maxRetries);
   }
 
   /**
@@ -56,9 +59,10 @@ public class Agent {
       case MISTRAL -> new MistralModel(config.getApiKey(), config.getModelName(), config.getBaseUrl());
       case AZURE_OPEN_AI -> new AzureOpenAiModel(config.getApiKey(), config.getBaseUrl());
       case OLLAMA -> new OllamaModel(config.getBaseUrl(), config.getModelName());
+      case QWEN, THOUSAND_QUESTIONS -> new QwenModel(config.getApiKey(), config.getModelName(), config.getBaseUrl());
     };
 
-    return new Agent(driver, model);
+    return new Agent(driver, model, TaskCache.disabled(), config.getMaxRetries());
   }
 
   /**
@@ -77,9 +81,10 @@ public class Agent {
       case MISTRAL -> new MistralModel(config.getApiKey(), config.getModelName(), config.getBaseUrl());
       case AZURE_OPEN_AI -> new AzureOpenAiModel(config.getApiKey(), config.getBaseUrl());
       case OLLAMA -> new OllamaModel(config.getBaseUrl(), config.getModelName());
+      case QWEN, THOUSAND_QUESTIONS -> new QwenModel(config.getApiKey(), config.getModelName(), config.getBaseUrl());
     };
 
-    return new Agent(driver, model, cache);
+    return new Agent(driver, model, cache, config.getMaxRetries());
   }
 
   /**

--- a/midscene-core/src/main/java/com/midscene/core/agent/Orchestrator.java
+++ b/midscene-core/src/main/java/com/midscene/core/agent/Orchestrator.java
@@ -20,15 +20,20 @@ public class Orchestrator {
   private final PageDriver driver;
   private final Planner planner;
   private final Executor executor;
+  private final int maxRetries;
   @Getter
   private final Context context;
 
   public Orchestrator(PageDriver driver, AIModel aiModel) {
-    this(driver, new Planner(aiModel, TaskCache.disabled()), new Executor(driver));
+    this(driver, new Planner(aiModel, TaskCache.disabled()), new Executor(driver), 3);
   }
 
   public Orchestrator(PageDriver driver, AIModel aiModel, TaskCache cache) {
-    this(driver, new Planner(aiModel, cache), new Executor(driver));
+    this(driver, new Planner(aiModel, cache), new Executor(driver), 3);
+  }
+
+  public Orchestrator(PageDriver driver, AIModel aiModel, TaskCache cache, int maxRetries) {
+    this(driver, new Planner(aiModel, cache), new Executor(driver), maxRetries);
   }
 
   /**
@@ -39,9 +44,14 @@ public class Orchestrator {
    * @param executor The executor
    */
   protected Orchestrator(PageDriver driver, Planner planner, Executor executor) {
+    this(driver, planner, executor, 3);
+  }
+
+  protected Orchestrator(PageDriver driver, Planner planner, Executor executor, int maxRetries) {
     this.driver = driver;
     this.planner = planner;
     this.executor = executor;
+    this.maxRetries = maxRetries;
     this.context = new Context();
   }
 
@@ -75,7 +85,6 @@ public class Orchestrator {
     context.logInstruction(instruction);
 
     List<ChatMessage> history = new ArrayList<>();
-    int maxRetries = 3;
     boolean finished = false;
     boolean cacheInvalidated = false;
 

--- a/midscene-core/src/main/java/com/midscene/core/config/MidsceneConfig.java
+++ b/midscene-core/src/main/java/com/midscene/core/config/MidsceneConfig.java
@@ -7,6 +7,7 @@ public class MidsceneConfig {
   private final String modelName;
   private final String baseUrl;
   private final long timeoutMs;
+  private final int maxRetries;
 
   private MidsceneConfig(Builder builder) {
     this.provider = builder.provider;
@@ -14,6 +15,7 @@ public class MidsceneConfig {
     this.modelName = builder.modelName;
     this.baseUrl = builder.baseUrl;
     this.timeoutMs = builder.timeoutMs;
+    this.maxRetries = builder.maxRetries;
   }
 
   public static Builder builder() {
@@ -40,6 +42,10 @@ public class MidsceneConfig {
     return baseUrl;
   }
 
+  public int getMaxRetries() {
+    return maxRetries;
+  }
+
   public static class Builder {
 
     private ModelProvider provider = ModelProvider.OPENAI;
@@ -47,6 +53,7 @@ public class MidsceneConfig {
     private String modelName;
     private String baseUrl;
     private long timeoutMs = 30000; // Default 30s
+    private int maxRetries = 3;
 
     public Builder provider(ModelProvider provider) {
       this.provider = provider;
@@ -70,6 +77,11 @@ public class MidsceneConfig {
 
     public Builder baseUrl(String baseUrl) {
       this.baseUrl = baseUrl;
+      return this;
+    }
+
+    public Builder maxRetries(int maxRetries) {
+      this.maxRetries = maxRetries;
       return this;
     }
 

--- a/midscene-core/src/main/java/com/midscene/core/config/ModelProvider.java
+++ b/midscene-core/src/main/java/com/midscene/core/config/ModelProvider.java
@@ -6,7 +6,9 @@ public enum ModelProvider {
   ANTHROPIC("claude-3-5-sonnet-20240620", "https://api.anthropic.com/v1/"),
   MISTRAL("small-latest", "https://api.mistral.ai/v1"),
   AZURE_OPEN_AI("gpt-4o", "https://openai.azure.com/"),
-  OLLAMA("llama3.1", "http://localhost:11434/");
+  OLLAMA("llama3.1", "http://localhost:11434/"),
+  QWEN("qwen-plus", "https://dashscope.aliyuncs.com/compatible-mode/v1"),
+  THOUSAND_QUESTIONS("qwen-plus", "https://dashscope.aliyuncs.com/compatible-mode/v1");
 
   private final String modelName;
   private final String baseUrl;

--- a/midscene-core/src/main/java/com/midscene/core/model/QwenModel.java
+++ b/midscene-core/src/main/java/com/midscene/core/model/QwenModel.java
@@ -1,0 +1,25 @@
+package com.midscene.core.model;
+
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import java.util.List;
+
+public class QwenModel implements AIModel {
+
+  private final ChatModel model;
+
+  public QwenModel(String apiKey, String modelName, String baseUrl) {
+    this.model = OpenAiChatModel.builder()
+        .apiKey(apiKey)
+        .modelName(modelName)
+        .baseUrl(baseUrl)
+        .build();
+  }
+
+  @Override
+  public ChatResponse chat(List<ChatMessage> messages) {
+    return model.chat(messages);
+  }
+}


### PR DESCRIPTION
This PR introduces support for Alibaba Tongyi Qianwen (Qwen) via the OpenAI-compatible DashScope API. It also adds a configurable `maxRetries` option to `MidsceneConfig`, replacing the hardcoded value in `Orchestrator`.

Changes:
- `MidsceneConfig`: Added `maxRetries` field and builder method.
- `ModelProvider`: Added `QWEN` and `THOUSAND_QUESTIONS` enums.
- `QwenModel`: New class implementing `AIModel` for Qwen.
- `Agent`: Updated factory methods to support new models and pass retry config.
- `Orchestrator`: Updated to use configured retry limit.

---
*PR created automatically by Jules for task [3205371919194446118](https://jules.google.com/task/3205371919194446118) started by @alstafeev*