### PR TITLE
🔒 fix: Path Traversal in Cache Configuration

### DIFF
--- a/midscene-core/src/main/java/com/midscene/core/yaml/ScriptPlayer.java
+++ b/midscene-core/src/main/java/com/midscene/core/yaml/ScriptPlayer.java
@@ -308,7 +308,15 @@ public class ScriptPlayer {
       
       Path cachePath = null;
       if (cacheConfig.getId() != null && !cacheConfig.getId().isEmpty()) {
-        cachePath = Path.of(cacheConfig.getId() + ".cache.json");
+        // Sanitize cache ID to prevent path traversal
+        String sanitizedId = cacheConfig.getId().replace('\\', '/');
+        Path idPath = Path.of(sanitizedId).getFileName();
+        if (idPath != null) {
+          String fileName = idPath.toString();
+          if (!fileName.isEmpty() && !fileName.equals(".") && !fileName.equals("..")) {
+            cachePath = Path.of(fileName + ".cache.json");
+          }
+        }
       }
       
       // Note: This updates agent's cache field but the Orchestrator/Planner already

--- a/midscene-core/src/test/java/com/midscene/core/yaml/ScriptPlayerSecurityTest.java
+++ b/midscene-core/src/test/java/com/midscene/core/yaml/ScriptPlayerSecurityTest.java
@@ -1,0 +1,60 @@
+package com.midscene.core.yaml;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.midscene.core.agent.Agent;
+import com.midscene.core.cache.TaskCache;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+
+class ScriptPlayerSecurityTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void testCacheIdPathTraversalFix() throws IOException, NoSuchFieldException, IllegalAccessException {
+        Agent agent = mock(Agent.class);
+
+        // Create a YAML with a malicious cache ID
+        String maliciousId = "../outside_cache";
+        File yamlFile = tempDir.resolve("malicious_script.yaml").toFile();
+        try (FileWriter writer = new FileWriter(yamlFile)) {
+            writer.write("agent:\n" +
+                         "  cache:\n" +
+                         "    id: \"" + maliciousId + "\"\n" +
+                         "    strategy: \"read-write\"\n" +
+                         "tasks: []");
+        }
+
+        // Create ScriptPlayer
+        new ScriptPlayer(yamlFile.getAbsolutePath(), agent);
+
+        // Capture the TaskCache passed to agent.setCache
+        ArgumentCaptor<TaskCache> cacheCaptor = ArgumentCaptor.forClass(TaskCache.class);
+        verify(agent, atLeastOnce()).setCache(cacheCaptor.capture());
+
+        TaskCache capturedCache = cacheCaptor.getValue();
+        assertNotNull(capturedCache);
+
+        // Use reflection to check the private cacheFilePath in TaskCache
+        Field field = TaskCache.class.getDeclaredField("cacheFilePath");
+        field.setAccessible(true);
+        Path cachePath = (Path) field.get(capturedCache);
+
+        // After fix, it should be "outside_cache.cache.json"
+        assertFalse(cachePath.toString().contains(".."), "Path should not contain '..'");
+        assertEquals("outside_cache.cache.json", cachePath.toString(), "Path should be sanitized to filename only");
+    }
+}


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is a Path Traversal issue in `ScriptPlayer.java`.
⚠️ **Risk:** A malicious or improperly configured YAML script could use the `agent.cache.id` field to read from or write to arbitrary locations on the filesystem by using path traversal sequences like `../` or absolute paths.
🛡️ **Solution:** Implemented sanitization of the cache ID using `Path.getFileName()` after normalizing slashes. This ensures that only the filename portion of the ID is used, effectively confining the cache files to the current working directory. Added validation to handle cases where `getFileName()` might return traversal-only components or empty strings. Added a security-focused test case to verify the fix.

---
*PR created automatically by Jules for task [15518531550143974011](https://jules.google.com/task/15518531550143974011) started by @alstafeev*