### PR TITLE
🔒 [security] Fix Path Traversal in TaskCache

### DIFF
--- a/midscene-core/src/main/java/com/midscene/core/cache/TaskCache.java
+++ b/midscene-core/src/main/java/com/midscene/core/cache/TaskCache.java
@@ -42,8 +42,11 @@ public class TaskCache {
     this.mode = mode;
     this.cacheFilePath = cacheFilePath;
 
-    if (cacheFilePath != null && mode != CacheMode.DISABLED) {
-      loadFromFile();
+    if (cacheFilePath != null) {
+      validatePath(cacheFilePath);
+      if (mode != CacheMode.DISABLED) {
+        loadFromFile();
+      }
     }
   }
 
@@ -194,6 +197,15 @@ public class TaskCache {
   }
 
   /**
+   * Gets the cache file path.
+   *
+   * @return the cache file path
+   */
+  public Path getCacheFilePath() {
+    return cacheFilePath;
+  }
+
+  /**
    * Gets the current cache mode.
    *
    * @return the cache mode
@@ -209,6 +221,29 @@ public class TaskCache {
    */
   public void setMode(CacheMode mode) {
     this.mode = mode;
+  }
+
+  /**
+   * Validates that the cache file path is within the allowed directory.
+   *
+   * @param path the path to validate
+   * @throws IllegalArgumentException if the path is invalid or outside the allowed directory
+   */
+  private void validatePath(Path path) {
+    try {
+      Path canonicalPath = path.toFile().getCanonicalFile().toPath();
+      Path currentDir = new java.io.File(".").getCanonicalFile().toPath();
+      Path tempDir = new java.io.File(System.getProperty("java.io.tmpdir")).getCanonicalFile().toPath();
+
+      if (!canonicalPath.startsWith(currentDir) && !canonicalPath.startsWith(tempDir)) {
+        throw new SecurityException("Access denied: Path traversal detected in cache file path: " + path);
+      }
+    } catch (Exception e) {
+      if (e instanceof SecurityException) {
+        throw (SecurityException) e;
+      }
+      throw new IllegalArgumentException("Invalid cache file path: " + path, e);
+    }
   }
 
   /**

--- a/midscene-core/src/main/java/com/midscene/core/yaml/ScriptPlayer.java
+++ b/midscene-core/src/main/java/com/midscene/core/yaml/ScriptPlayer.java
@@ -308,7 +308,20 @@ public class ScriptPlayer {
       
       Path cachePath = null;
       if (cacheConfig.getId() != null && !cacheConfig.getId().isEmpty()) {
-        cachePath = Path.of(cacheConfig.getId() + ".cache.json");
+        // Resolve cache path against current directory and ensure it stays within it
+        try {
+          Path currentDir = new java.io.File(".").getCanonicalFile().toPath();
+          Path resolvedPath = currentDir.resolve(cacheConfig.getId() + ".cache.json").toFile().getCanonicalFile().toPath();
+          if (resolvedPath.startsWith(currentDir)) {
+            cachePath = Path.of(cacheConfig.getId() + ".cache.json");
+          } else {
+            log.warn("Cache ID escapes base directory: {}. Cache will be disabled.", cacheConfig.getId());
+            mode = TaskCache.CacheMode.DISABLED;
+          }
+        } catch (IOException e) {
+          log.warn("Failed to resolve cache path for ID: {}. Cache will be disabled.", cacheConfig.getId(), e);
+          mode = TaskCache.CacheMode.DISABLED;
+        }
       }
       
       // Note: This updates agent's cache field but the Orchestrator/Planner already

--- a/midscene-core/src/test/java/com/midscene/core/cache/SecurityReproductionTest.java
+++ b/midscene-core/src/test/java/com/midscene/core/cache/SecurityReproductionTest.java
@@ -1,0 +1,44 @@
+package com.midscene.core.cache;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.io.IOException;
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SecurityReproductionTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    public void testPathTraversal() throws IOException {
+        // This test demonstrates that TaskCache should block paths outside the intended directory.
+        // We use an absolute path that is definitely outside the project and temp directory.
+        Path outsidePath = Paths.get("/outside_cache_test.json");
+
+        // Verification: it should throw a SecurityException
+        assertThrows(SecurityException.class, () -> {
+            TaskCache.withFile(outsidePath);
+        });
+    }
+
+    @Test
+    public void testLegitimatePath() throws IOException {
+        // This test ensures that legitimate paths within the current directory are allowed.
+        Path relativePath = Paths.get("cache_test.json");
+        TaskCache cache = TaskCache.withFile(relativePath);
+        assertEquals(relativePath, cache.getCacheFilePath());
+    }
+
+    @Test
+    public void testTempDirPath() throws IOException {
+        // This test ensures that paths within the system temp directory are allowed.
+        Path tempFilePath = Paths.get(System.getProperty("java.io.tmpdir"), "cache_test.json");
+        TaskCache cache = TaskCache.withFile(tempFilePath);
+        assertEquals(tempFilePath, cache.getCacheFilePath());
+    }
+}


### PR DESCRIPTION
🎯 **What:** Fixed a path traversal vulnerability in the `TaskCache` file persistence logic.

⚠️ **Risk:** Potential for unauthorized file access or modification. If left unfixed, a malicious user or configuration could specify a cache file path outside the intended directory (e.g., `../../etc/passwd`), potentially leading to information disclosure or system instability.

🛡️ **Solution:** 
- Implemented `validatePath` in `TaskCache` which resolves the provided path to its canonical form (resolving symlinks and `..` segments) and verifies it starts with an allowed base directory (the current working directory or the system temporary directory) using the component-aware `Path.startsWith` method.
- Updated `ScriptPlayer` to securely resolve user-provided cache IDs against the project root, ensuring they cannot escape the intended directory structure.
- Added a new unit test `SecurityReproductionTest` that explicitly verifies both successful path validation for legitimate locations and failure for traversal attempts.

---
*PR created automatically by Jules for task [9937300537152292244](https://jules.google.com/task/9937300537152292244) started by @alstafeev*