### PR TITLE
🧪 Add test for ObjectMapper.writeValueAsString exception handling

### DIFF
--- a/midscene-core/src/test/java/com/midscene/core/utils/ObjectMapperTest.java
+++ b/midscene-core/src/test/java/com/midscene/core/utils/ObjectMapperTest.java
@@ -1,6 +1,8 @@
 package com.midscene.core.utils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import lombok.Data;
 import org.junit.jupiter.api.Test;
 
@@ -30,10 +32,28 @@ class ObjectMapperTest {
     assertEquals(123, result.getValue());
   }
 
+  @Test
+  void testWriteValueAsStringException() {
+    CyclicObject cyclicObject = new CyclicObject();
+    cyclicObject.setSelf(cyclicObject);
+
+    RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+      ObjectMapper.writeValueAsString(cyclicObject);
+    });
+
+    assertEquals("Failed to encode json", exception.getMessage());
+  }
+
   @Data
   static class TestPojo {
 
     private String name;
     private int value;
+  }
+
+  @Data
+  static class CyclicObject {
+
+    private CyclicObject self;
   }
 }


### PR DESCRIPTION
🎯 **What:** Added unit test for `ObjectMapper.writeValueAsString` exception handling.
📊 **Coverage:** Scenario where an object with a cyclical dependency is passed for serialization, which triggers a `JsonProcessingException`.
✨ **Result:** Verified that the utility correctly catches the exception and re-throws it as a `RuntimeException` with the expected error message, improving the reliability of the utility class.

---
*PR created automatically by Jules for task [6111409061022767793](https://jules.google.com/task/6111409061022767793) started by @alstafeev*